### PR TITLE
ci(runner): Check Invalidation Complete before Triggering Site Workflow

### DIFF
--- a/.github/workflows/BuildNDeployDev.yml
+++ b/.github/workflows/BuildNDeployDev.yml
@@ -4,7 +4,6 @@ on: # run this workflow when a push has been made to `Jekyll-Alf` branch
   push:
     branches:
       - development
-      - ghi-14
 
 jobs:
   deploy:

--- a/.github/workflows/BuildNDeployDev.yml
+++ b/.github/workflows/BuildNDeployDev.yml
@@ -4,6 +4,7 @@ on: # run this workflow when a push has been made to `Jekyll-Alf` branch
   push:
     branches:
       - development
+      - ghi-14
 
 jobs:
   deploy:
@@ -57,6 +58,9 @@ jobs:
         
         - name: Invalidate CloudFront Cache # Invalidate the CloudFront Distribution Cache to get contents from the S3 bucket
           run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_DISTRIBUTION_ID_DEV }} --paths "/*"
+
+        - name: Check Invalidation Complete
+          run: ./scripts/check_invalidations.sh
 
         - name: Trigger open-sdg-site-starter workflow
           run: |

--- a/.github/workflows/BuildNDeployDev.yml
+++ b/.github/workflows/BuildNDeployDev.yml
@@ -19,13 +19,11 @@ jobs:
  ###########################################################################################################
         - name: Checkout repo
           uses: actions/checkout@v2
-          
-          
+             
  ###########################################################################################################
  #      This is the CD portion
  ###########################################################################################################       
           
-      
         - name: Setup Python
           uses: actions/setup-python@v1 # sets up python in our environment
           with:
@@ -35,15 +33,12 @@ jobs:
         - name: Install Python dependencies requirements
           run: pip3 install -r scripts/requirements.txt
 
-        
-        
         - name: Build site data
           run: python3 scripts/build_data.py
         
         - name: Install AWS CLI
           run: pip3 install awscli --upgrade --user # install the cli with upgrade to any requirements and into the subdir of the user
-          
-          
+            
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@v1 # use the official GitHub Action from AWS to setup credentials
           with:
@@ -52,7 +47,6 @@ jobs:
             aws-region: ${{ secrets.AWS_REGION }}
             mask-aws-account-id: true
         
-    
         - name: Push Contents to S3 # push the current working directory to the S3 bucket
           run: aws s3 sync _site/ s3://${{ secrets.S3_BUCKET_NAME_DEV }} --exclude ".git/*" --exclude ".github/*" --delete # have the bucket have the same content in the repo & exclude the git related directories.
         
@@ -71,6 +65,4 @@ jobs:
             -H "Content-Type: application/json" \
             https://api.github.com/repos/CityOfLosAngeles/open-sdg-site-starter/dispatches \
             -d '{"event_type":"dev_triggered_from_open-sdg-data-starter"}'
-              
-          
-          
+        

--- a/.github/workflows/BuildNDeployDev.yml
+++ b/.github/workflows/BuildNDeployDev.yml
@@ -4,6 +4,7 @@ on: # run this workflow when a push has been made to `Jekyll-Alf` branch
   push:
     branches:
       - development
+      - ghi-14
 
 jobs:
   deploy:

--- a/.github/workflows/BuildNDeployDev.yml
+++ b/.github/workflows/BuildNDeployDev.yml
@@ -1,10 +1,9 @@
 name: Build and Deploy Development Data
 
-on: # run this workflow when a push has been made to `Jekyll-Alf` branch
+on: # run this workflow when a push has been made to development branch
   push:
     branches:
       - development
-      - ghi-14
 
 jobs:
   deploy:
@@ -54,7 +53,7 @@ jobs:
         - name: Invalidate CloudFront Cache # Invalidate the CloudFront Distribution Cache to get contents from the S3 bucket
           run: aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DIST_ID" --paths "/*"
 
-        - name: Check Invalidation Complete
+        - name: Check Invalidation is Complete
           run: ./scripts/check_invalidations.sh
 
         - name: Trigger open-sdg-site-starter workflow

--- a/.github/workflows/BuildNDeployDev.yml
+++ b/.github/workflows/BuildNDeployDev.yml
@@ -13,6 +13,7 @@ jobs:
       # Service Account info to trigger open-sdg-site-starter workflow
       PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      CLOUDFRONT_DIST_ID: ${{ secrets.CDN_DISTRIBUTION_ID_DEV }}
     steps:   
  ###########################################################################################################
  #      This is the CI portion
@@ -57,7 +58,7 @@ jobs:
           run: aws s3 sync _site/ s3://${{ secrets.S3_BUCKET_NAME_DEV }} --exclude ".git/*" --exclude ".github/*" --delete # have the bucket have the same content in the repo & exclude the git related directories.
         
         - name: Invalidate CloudFront Cache # Invalidate the CloudFront Distribution Cache to get contents from the S3 bucket
-          run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_DISTRIBUTION_ID_DEV }} --paths "/*"
+          run: aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DIST_ID" --paths "/*"
 
         - name: Check Invalidation Complete
           run: ./scripts/check_invalidations.sh

--- a/.github/workflows/BuildNDeployProd.yml
+++ b/.github/workflows/BuildNDeployProd.yml
@@ -12,37 +12,32 @@ jobs:
       # Service Account info to trigger open-sdg-site-starter workflow
       PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      CLOUDFRONT_DIST_ID: ${{ secrets.CDN_DISTRIBUTION_ID_PROD }}
     steps:   
  ###########################################################################################################
  #      This is the CI portion
  ###########################################################################################################
         - name: Checkout repo
           uses: actions/checkout@v2
-          
-          
+               
  ###########################################################################################################
  #      This is the CD portion
  ###########################################################################################################       
-          
-        #- uses: actions/checkout@v1 # checks out the code in the repository
+
         - name: Setup Python
           uses: actions/setup-python@v1 # sets up python in our environment
           with:
             python-version: '3.x' # install python version 3.x, default architecture is x64
                  
-          
           # this Action should follow steps to set up Python build environment
         - name: Install Python dependencies requirements
           run: pip3 install -r scripts/requirements.txt
-
-        
-        
+      
         - name: Build site data
           run: python3 scripts/build_data.py
         
         - name: Install AWS CLI
           run: pip3 install awscli --upgrade --user # install the cli with upgrade to any requirements and into the subdir of the user
-          
           
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@v1 # use the official GitHub Action from AWS to setup credentials
@@ -52,12 +47,14 @@ jobs:
             aws-region: ${{ secrets.AWS_REGION }}
             mask-aws-account-id: true
         
-    
         - name: Push Contents to S3 # push the current working directory to the S3 bucket
           run: aws s3 sync _site/ s3://${{ secrets.S3_BUCKET_NAME_PROD }} --exclude ".git/*" --exclude ".github/*" --delete # have the bucket have the same content in the repo & exclude the git related directories.
         
         - name: Invalidate CloudFront Cache # Invalidate the CloudFront Distribution Cache to get contents from the S3 bucket
-          run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_DISTRIBUTION_ID_PROD }} --paths "/*"
+          run: aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DIST_ID" --paths "/*"
+
+        - name: Check Invalidation Complete
+          run: ./scripts/check_invalidations.sh
 
         - name: Trigger open-sdg-site-starter workflow
           run: |
@@ -68,6 +65,3 @@ jobs:
             -H "Content-Type: application/json" \
             https://api.github.com/repos/CityOfLosAngeles/open-sdg-site-starter/dispatches \
             -d '{"event_type":"prod_triggered_from_open-sdg-data-starter"}'
-              
-          
-          

--- a/.github/workflows/BuildNDeployProd.yml
+++ b/.github/workflows/BuildNDeployProd.yml
@@ -1,6 +1,6 @@
 name: Build and Deploy Production Data
 
-on: # run this workflow when a push has been made to `Jekyll-Alf` branch
+on: # run this workflow when a push has been made to production branch
   push:
     branches:
       - production
@@ -53,7 +53,7 @@ jobs:
         - name: Invalidate CloudFront Cache # Invalidate the CloudFront Distribution Cache to get contents from the S3 bucket
           run: aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DIST_ID" --paths "/*"
 
-        - name: Check Invalidation Complete
+        - name: Check Invalidation is Complete
           run: ./scripts/check_invalidations.sh
 
         - name: Trigger open-sdg-site-starter workflow

--- a/.github/workflows/BuildNDeployProd.yml
+++ b/.github/workflows/BuildNDeployProd.yml
@@ -5,7 +5,6 @@ on: # run this workflow when a push has been made to `Jekyll-Alf` branch
     branches:
       - production
 
-
 jobs:
   deploy:
     runs-on: ubuntu-20.04

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -68,8 +68,7 @@ function checkInvalidationstatus(){
 				checkInvalidationstatus
 			done
 			if [ $invalidationStatus = "Completed" ]; then
-					echo "CloudFront Invalidation $invalidationStatus"
-					break
+				echo "CloudFront Invalidation $invalidationStatus"
 			fi	
 		done
 		completed

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -20,6 +20,7 @@ function completed(){
 	echo "Completed!"
 	HorizontalRule
 	echo
+	exit 0
 }
 
 # Fail
@@ -68,8 +69,10 @@ function checkInvalidationstatus(){
 				checkInvalidationstatus
 			done
 
-			echo "CloudFront Invalidation $invalidationStatus"
-			completed
+			if [ $invalidationStatus = "Completed" ]; then
+				echo "CloudFront Invalidation $invalidationStatus"
+				completed
+			fi
 		done <<< "$invalidations"
 	fi
 }

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -38,11 +38,11 @@ function HorizontalRule(){
 
 # Verify AWS CLI Credentials are setup
 # http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
-if ! grep -q aws_access_key_id ~/.aws/config; then
-	if ! grep -q aws_access_key_id ~/.aws/credentials; then
-		fail "AWS config not found or CLI not installed. Please run \"aws configure\"."
-	fi
-fi
+# if ! grep -q aws_access_key_id ~/.aws/config; then
+# 	if ! grep -q aws_access_key_id ~/.aws/credentials; then
+# 		fail "AWS config not found or CLI not installed. Please run \"aws configure\"."
+# 	fi
+# fi
 
 # Check for AWS CLI profile argument passed into the script
 # http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles
@@ -58,42 +58,42 @@ else
 fi
 
 # Check for Distributions
-function distributionsCheck(){
-	distributions=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .ARN')
-	if [[ $DEBUGMODE = "1" ]]; then
-		echo "$distributions"
-	fi
-	if echo "$distributions" | egrep -iq "error|not|false"; then
-		echo "$distributions"
-		fail "No CloudFront distributions found."
-	fi
-}
+# function distributionsCheck(){
+# 	distributions=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .ARN')
+# 	if [[ $DEBUGMODE = "1" ]]; then
+# 		echo "$distributions"
+# 	fi
+# 	if echo "$distributions" | egrep -iq "error|not|false"; then
+# 		echo "$distributions"
+# 		fail "No CloudFront distributions found."
+# 	fi
+# }
 
 # List Distributions
-function listDistributions(){
-	distributions=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .Id' | cut -d \" -f2)
-	names=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .Origins | .Items | .[] | .Id' | cut -d \" -f2)
+# function listDistributions(){
+# 	distributions=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .Id' | cut -d \" -f2)
+# 	names=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .Origins | .Items | .[] | .Id' | cut -d \" -f2)
 
-	if [ -z "$distributions" ]; then
-		echo "$distributions"
-		fail "No CloudFront distributions found."
-	else
-		HorizontalRule
-		echo Found CloudFront Distributions:
-		HorizontalRule
+# 	if [ -z "$distributions" ]; then
+# 		echo "$distributions"
+# 		fail "No CloudFront distributions found."
+# 	else
+# 		HorizontalRule
+# 		echo Found CloudFront Distributions:
+# 		HorizontalRule
 
-		if [[ $DEBUGMODE = "1" ]]; then
-			echo "Debug distribution IDs:"
-			echo "$distributions"
-		fi
-		echo "$names"
-		echo
-	fi
-	TOTALDISTRIBUTIONS=$(echo "$distributions" | wc -l | rev | cut -d " " -f1 | rev)
-	if [[ $DEBUGMODE = "1" ]]; then
-		echo "$TOTALDISTRIBUTIONS"
-	fi
-}
+# 		if [[ $DEBUGMODE = "1" ]]; then
+# 			echo "Debug distribution IDs:"
+# 			echo "$distributions"
+# 		fi
+# 		echo "$names"
+# 		echo
+# 	fi
+# 	TOTALDISTRIBUTIONS=$(echo "$distributions" | wc -l | rev | cut -d " " -f1 | rev)
+# 	if [[ $DEBUGMODE = "1" ]]; then
+# 		echo "$TOTALDISTRIBUTIONS"
+# 	fi
+# }
 
 # List Invalidations
 function listInvalidations(){
@@ -103,27 +103,13 @@ function listInvalidations(){
 	echo "Checking for Invalidations In Progress..."
 	HorizontalRule
 
-	START=1
-	for (( COUNT=$START; COUNT<=$TOTALDISTRIBUTIONS; COUNT++ ))
-	do
-		distributionid=$(echo "$distributions" | nl | grep -w [^0-9][[:space:]]$COUNT | cut -f2)
+	invalidations=$(aws cloudfront list-invalidations --distribution-id $CLOUDFRONT_DIST_ID --profile $profile 2>&1 | jq '.InvalidationList | .Items | .[] | select(.Status != "Completed") | .Id' | cut -d \" -f2)
 
-		if [[ $DEBUGMODE = "1" ]]; then
-			echo "Debug distribution ID: $distributionid"
-		fi
-		invalidations=$(aws cloudfront list-invalidations --distribution-id $distributionid --profile $profile 2>&1 | jq '.InvalidationList | .Items | .[] | select(.Status != "Completed") | .Id' | cut -d \" -f2)
-		if [[ $DEBUGMODE = "1" ]]; then
-			echo invalidations "$invalidations"
-		fi
-
-		if ! [ -z "$invalidations" ]; then
-			HorizontalRule
-			echo "Invalidation in progress: $invalidations"
-			HorizontalRule
-		fi
-	done
-
-	# done <<< "$distributions"
+	if ! [ -z "$invalidations" ]; then
+		HorizontalRule
+		echo "Invalidation in progress: $invalidations"
+		HorizontalRule
+	fi
 }
 
 # Check the Invalidation Status
@@ -164,7 +150,7 @@ function checkInvalidationstatus(){
 }
 
 check_command "jq"
-distributionsCheck
-listDistributions
+#distributionsCheck
+#listDistributions
 listInvalidations
 checkInvalidationstatus

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -38,7 +38,6 @@ function HorizontalRule(){
 function listInvalidations(){
 	HorizontalRule
 	echo "Checking for Invalidations In Progress..."
-	HorizontalRule
 
 	invalidations=$(aws cloudfront list-invalidations --distribution-id $CLOUDFRONT_DIST_ID | jq '.InvalidationList | .Items | .[] | select(.Status != "Completed") | .Id' | cut -d \" -f2)
 	if ! [ -z "$invalidations" ]; then
@@ -57,12 +56,12 @@ function checkInvalidationstatus(){
 	else
 		while IFS= read -r invalidationid
 		do
-			echo Invalidation ID: $invalidationid
 			invalidationStatus=$(aws cloudfront get-invalidation --distribution-id $CLOUDFRONT_DIST_ID --id $invalidationid | jq '.Invalidation | .Status' | cut -d \" -f2)
 
 			while [ $invalidationStatus = "InProgress" ]; do
 				HorizontalRule
-				echo "Invalidation Status:" $invalidationStatus
+				echo "Invalidation ID: $invalidationid" 
+				echo "Status: $invalidationStatus"
 				echo "Waiting for invalidation to complete..."
 				HorizontalRule
 				sleep 10

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -59,7 +59,8 @@ function checkInvalidationstatus(){
 		while IFS= read -r invalidationid
 		do
 			echo "Waiting for invalidation $invalidationid to complete..."
-			# Poll every 20 seconds, Wait until invalidation has completed
+			# Poll every 20 seconds (built into AWS command), Wait until invalidation has completed
+			# See https://docs.aws.amazon.com/cli/latest/reference/cloudfront/wait/invalidation-completed.html for more info
 			aws cloudfront wait invalidation-completed --distribution-id "$CLOUDFRONT_DIST_ID" --id "$invalidationid"
 			HorizontalRule
 			echo "Invalidation $invalidationid completed"

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -61,8 +61,8 @@ function checkInvalidationstatus(){
 			echo "Waiting for invalidation $invalidationid to complete..."
 			# Poll every 20 seconds, Wait until invalidation has completed
 			aws cloudfront wait invalidation-completed --distribution-id "$CLOUDFRONT_DIST_ID" --id "$invalidationid"
-			echo "Invalidation $invalidationid completed"
 			HorizontalRule
+			echo "Invalidation $invalidationid completed"
 		done <<< "$invalidations"
 		# All invalidations completed, exit script
 		scriptExit

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -17,7 +17,7 @@ function check_command {
 function completed(){
 	echo
 	HorizontalRule
-	echo "Completed!"
+	echo "Exiting Script!"
 	HorizontalRule
 	echo
 	exit 0
@@ -52,7 +52,7 @@ function checkInvalidationstatus(){
 	if [ -z "$invalidations" ]; then
 		echo No CloudFront Invalidations In Progress.
 		HorizontalRule
-		return 1
+		completed
 	else
 		while IFS= read -r invalidationid
 		do
@@ -66,13 +66,13 @@ function checkInvalidationstatus(){
 				HorizontalRule
 				sleep 10
 				checkInvalidationstatus
-			done
-
-			if [ $invalidationStatus = "Completed" ]; then
-				echo "CloudFront Invalidation $invalidationStatus"
-				completed
-			fi
-		done <<< "$invalidations"
+				if [ $invalidationStatus = "Completed" ]; then
+					echo "CloudFront Invalidation $invalidationStatus"
+					break
+				fi
+			done	
+		done
+		completed
 	fi
 }
 

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -80,7 +80,7 @@ function checkInvalidationstatus(){
 				echo "CloudFront Invalidation $invalidationStatus"
 				completed
 			fi
-		done <<< "$invalidationid"
+		done <<< "$invalidations"
 	fi
 }
 

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -17,7 +17,7 @@ function check_command {
 function completed(){
 	echo
 	HorizontalRule
-	echo "Exiting Script!"
+	echo "Completed!"
 	HorizontalRule
 	echo
 	exit 0
@@ -52,7 +52,7 @@ function checkInvalidationstatus(){
 	if [ -z "$invalidations" ]; then
 		echo No CloudFront Invalidations In Progress.
 		HorizontalRule
-		completed
+		return 1
 	else
 		while IFS= read -r invalidationid
 		do
@@ -67,11 +67,12 @@ function checkInvalidationstatus(){
 				sleep 10
 				checkInvalidationstatus
 			done
+
 			if [ $invalidationStatus = "Completed" ]; then
 				echo "CloudFront Invalidation $invalidationStatus"
-			fi	
-		done
-		completed
+				completed
+			fi
+		done <<< "$invalidations"
 	fi
 }
 

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -55,10 +55,11 @@ function checkInvalidationstatus(){
 		HorizontalRule
 		return 1
 	else
+		# Loop through all invalidations
 		while IFS= read -r invalidationid
 		do
 			echo "Waiting for invalidation $invalidationid to complete..."
-			aws cloudfront invalidation-completed --distribution-id "$CLOUDFRONT_DIST_ID" --id "$invalidationid"
+			aws cloudfront wait invalidation-completed --distribution-id "$CLOUDFRONT_DIST_ID" --id "$invalidationid"
 			# # jq used to parse aws json output
 			# invalidationStatus=$(aws cloudfront get-invalidation --distribution-id $CLOUDFRONT_DIST_ID --id $invalidationid | jq '.Invalidation | .Status' | cut -d \" -f2)
 
@@ -79,6 +80,7 @@ function checkInvalidationstatus(){
 			# 	scriptExit
 			# fi
 		done <<< "$invalidations"
+		# All invalidations completed, exit script
 		scriptExit
 	fi
 }

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -9,18 +9,26 @@
 # Functions
 
 # Check Command
-function check_command {
+function checkCommand {
 	type -P $1 &>/dev/null || fail "Unable to find $1, please install it and run this script again."
 }
 
 # Completed
-function completed(){
-	echo
+function scriptExit(){
 	HorizontalRule
-	echo "Completed!"
+	echo "Exiting Script"
 	HorizontalRule
 	echo
 	exit 0
+}
+
+# Invalidation Completed
+function completed(){
+	echo
+	HorizontalRule
+	echo "Invalidation Completed!"
+	HorizontalRule
+	echo
 }
 
 # Fail
@@ -76,6 +84,7 @@ function checkInvalidationstatus(){
 	fi
 }
 
-check_command "jq"
+checkCommand "jq"
 listInvalidations
 checkInvalidationstatus
+scriptExit

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -46,16 +46,16 @@ function HorizontalRule(){
 
 # Check for AWS CLI profile argument passed into the script
 # http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles
-if [ $# -eq 0 ]; then
-	scriptname=`basename "$0"`
-	echo "Usage: ./$scriptname profile"
-	echo "Where profile is the AWS CLI profile name"
-	echo "Using default profile"
-	echo
-	profile=default
-else
-	profile=$1
-fi
+# if [ $# -eq 0 ]; then
+# 	scriptname=`basename "$0"`
+# 	echo "Usage: ./$scriptname profile"
+# 	echo "Where profile is the AWS CLI profile name"
+# 	echo "Using default profile"
+# 	echo
+# 	profile=default
+# else
+# 	profile=$1
+# fi
 
 # Check for Distributions
 # function distributionsCheck(){
@@ -103,8 +103,8 @@ function listInvalidations(){
 	echo "Checking for Invalidations In Progress..."
 	HorizontalRule
 
-	invalidations=$(aws cloudfront list-invalidations --distribution-id $CLOUDFRONT_DIST_ID --profile $profile 2>&1 | jq '.InvalidationList | .Items | .[] | select(.Status != "Completed") | .Id' | cut -d \" -f2)
-
+	invalidations=$(aws cloudfront list-invalidations --distribution-id $CLOUDFRONT_DIST_ID | jq '.InvalidationList | .Items | .[] | select(.Status != "Completed") | .Id' | cut -d \" -f2)
+    echo $invalidations
 	if ! [ -z "$invalidations" ]; then
 		HorizontalRule
 		echo "Invalidation in progress: $invalidations"
@@ -122,7 +122,7 @@ function checkInvalidationstatus(){
 		while IFS= read -r invalidationid
 		do
 			echo Invalidation ID: $invalidationid
-			invalidationStatus=$(aws cloudfront get-invalidation --distribution-id $distributionid --id $invalidationid --profile $profile 2>&1 | jq '.Invalidation | .Status' | cut -d \" -f2)
+			invalidationStatus=$(aws cloudfront get-invalidation --distribution-id $CLOUDFRONT_DIST_ID --id $invalidationid | jq '.Invalidation | .Status' | cut -d \" -f2)
 
 			while [ $invalidationStatus = "InProgress" ]; do
 				HorizontalRule

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -57,32 +57,34 @@ function checkInvalidationstatus(){
 	else
 		while IFS= read -r invalidationid
 		do
-			# jq used to parse aws json output
-			invalidationStatus=$(aws cloudfront get-invalidation --distribution-id $CLOUDFRONT_DIST_ID --id $invalidationid | jq '.Invalidation | .Status' | cut -d \" -f2)
+			echo "Waiting for invalidation $invalidationid to complete..."
+			aws cloudfront invalidation-completed --distribution-id "$CLOUDFRONT_DIST_ID" --id "$invalidationid"
+			# # jq used to parse aws json output
+			# invalidationStatus=$(aws cloudfront get-invalidation --distribution-id $CLOUDFRONT_DIST_ID --id $invalidationid | jq '.Invalidation | .Status' | cut -d \" -f2)
 
-			# While invalidation in progress, sleep for 10 seconds and check again
-			while [ $invalidationStatus = "InProgress" ]; do
-				HorizontalRule
-				echo "Invalidation ID: $invalidationid" 
-				echo "Status: $invalidationStatus"
-				echo "Waiting for invalidation to complete..."
-				HorizontalRule
-				sleep 10
-				checkInvalidationstatus
-			done
+			# # While invalidation in progress, sleep for 10 seconds and check again
+			# while [ $invalidationStatus = "InProgress" ]; do
+			# 	HorizontalRule
+			# 	echo "Invalidation ID: $invalidationid" 
+			# 	echo "Status: $invalidationStatus"
+			# 	echo "Waiting for invalidation to complete..."
+			# 	HorizontalRule
+			# 	sleep 10
+			# 	checkInvalidationstatus
+			# done
 
-			# If invalidation is completed, exit the script
-			if [ $invalidationStatus = "Completed" ]; then
-				echo "CloudFront Invalidation $invalidationStatus"
-				scriptExit
-			fi
+			# # If invalidation completes, exit the script
+			# if [ $invalidationStatus = "Completed" ]; then
+			# 	echo "CloudFront Invalidation $invalidationStatus"
+			# 	scriptExit
+			# fi
 		done <<< "$invalidations"
 	fi
 }
 
 # Make sure jq exists on the system
 checkCommand "jq"
-# Grab all invalidations
+# Grab invalidations
 listInvalidations
 # Make sure invalidations are completed
 checkInvalidationstatus

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -7,12 +7,12 @@
 
 # Functions
 
-# Check Command
+# Check Command Exists
 function checkCommand {
 	type -P $1 &>/dev/null || fail "Unable to find $1, please install it and run this script again."
 }
 
-# Completed
+# Completed Script
 function scriptExit(){
 	HorizontalRule
 	echo "Exiting Script"
@@ -21,23 +21,25 @@ function scriptExit(){
 	exit 0
 }
 
-# Fail
+# Script Failed
 function fail(){
 	echo "Failure: $*"
 	exit 1
 }
 
-# Horizontal Rule
+# Horizontal Rule, print divider line
 function HorizontalRule(){
 	echo "============================================================"
 }
 
-# List Invalidations
+# List Cloudfront Invalidations
 function listInvalidations(){
 	HorizontalRule
 	echo "Checking for Invalidations In Progress..."
 
+	# jq used to parse aws json output
 	invalidations=$(aws cloudfront list-invalidations --distribution-id $CLOUDFRONT_DIST_ID | jq '.InvalidationList | .Items | .[] | select(.Status != "Completed") | .Id' | cut -d \" -f2)
+	# Check if invalidation exists, if so output status
 	if ! [ -z "$invalidations" ]; then
 		HorizontalRule
 		echo "Invalidation in progress: $invalidations"
@@ -45,8 +47,9 @@ function listInvalidations(){
 	fi
 }
 
-# Check the Invalidation Status
+# Check the Cloudfront Invalidation Status
 function checkInvalidationstatus(){
+	# Check if invalidation exists, if not exit script
 	if [ -z "$invalidations" ]; then
 		echo No CloudFront Invalidations In Progress.
 		HorizontalRule
@@ -54,8 +57,10 @@ function checkInvalidationstatus(){
 	else
 		while IFS= read -r invalidationid
 		do
+			# jq used to parse aws json output
 			invalidationStatus=$(aws cloudfront get-invalidation --distribution-id $CLOUDFRONT_DIST_ID --id $invalidationid | jq '.Invalidation | .Status' | cut -d \" -f2)
 
+			# While invalidation in progress, sleep for 10 seconds and check again
 			while [ $invalidationStatus = "InProgress" ]; do
 				HorizontalRule
 				echo "Invalidation ID: $invalidationid" 
@@ -66,6 +71,7 @@ function checkInvalidationstatus(){
 				checkInvalidationstatus
 			done
 
+			# If invalidation is completed, exit the script
 			if [ $invalidationStatus = "Completed" ]; then
 				echo "CloudFront Invalidation $invalidationStatus"
 				scriptExit
@@ -74,6 +80,9 @@ function checkInvalidationstatus(){
 	fi
 }
 
+# Make sure jq exists on the system
 checkCommand "jq"
+# Grab all invalidations
 listInvalidations
+# Make sure invalidations are completed
 checkInvalidationstatus

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -80,7 +80,7 @@ function checkInvalidationstatus(){
 				echo "CloudFront Invalidation $invalidationStatus"
 				completed
 			fi
-		done
+		done <<< "$invalidationid"
 	fi
 }
 

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -66,11 +66,11 @@ function checkInvalidationstatus(){
 				HorizontalRule
 				sleep 10
 				checkInvalidationstatus
-				if [ $invalidationStatus = "Completed" ]; then
+			done
+			if [ $invalidationStatus = "Completed" ]; then
 					echo "CloudFront Invalidation $invalidationStatus"
 					break
-				fi
-			done	
+			fi	
 		done
 		completed
 	fi

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -80,7 +80,7 @@ function checkInvalidationstatus(){
 				echo "CloudFront Invalidation $invalidationStatus"
 				completed
 			fi
-		done <<< "$invalidations"
+		done
 	fi
 }
 

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -79,6 +79,7 @@ function checkInvalidationstatus(){
 			# 	scriptExit
 			# fi
 		done <<< "$invalidations"
+		scriptExit
 	fi
 }
 

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+# Taken from https://github.com/swoodford/aws/blob/master/cloudfront-invalidation-status.sh
+
+# This script monitors CloudFront distributions for cache invalidation status and alerts when it has completed
+# Requires the AWS CLI and jq
+
+# Debug Mode
+DEBUGMODE="0"
+
+
+# Functions
+
+# Check Command
+function check_command {
+	type -P $1 &>/dev/null || fail "Unable to find $1, please install it and run this script again."
+}
+
+# Completed
+function completed(){
+	echo
+	HorizontalRule
+	tput setaf 2; echo "Completed!" && tput sgr0
+	HorizontalRule
+	echo
+}
+
+# Fail
+function fail(){
+	tput setaf 1; echo "Failure: $*" && tput sgr0
+	exit 1
+}
+
+# Horizontal Rule
+function HorizontalRule(){
+	echo "============================================================"
+}
+
+# Verify AWS CLI Credentials are setup
+# http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
+if ! grep -q aws_access_key_id ~/.aws/config; then
+	if ! grep -q aws_access_key_id ~/.aws/credentials; then
+		fail "AWS config not found or CLI not installed. Please run \"aws configure\"."
+	fi
+fi
+
+# Check for AWS CLI profile argument passed into the script
+# http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles
+if [ $# -eq 0 ]; then
+	scriptname=`basename "$0"`
+	echo "Usage: ./$scriptname profile"
+	echo "Where profile is the AWS CLI profile name"
+	echo "Using default profile"
+	echo
+	profile=default
+else
+	profile=$1
+fi
+
+# Check for Distributions
+function distributionsCheck(){
+	distributions=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .ARN')
+	if [[ $DEBUGMODE = "1" ]]; then
+		echo "$distributions"
+	fi
+	if echo "$distributions" | egrep -iq "error|not|false"; then
+		echo "$distributions"
+		fail "No CloudFront distributions found."
+	fi
+}
+
+# List Distributions
+function listDistributions(){
+	distributions=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .Id' | cut -d \" -f2)
+	names=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .Origins | .Items | .[] | .Id' | cut -d \" -f2)
+
+	if [ -z "$distributions" ]; then
+		echo "$distributions"
+		fail "No CloudFront distributions found."
+	else
+		HorizontalRule
+		echo Found CloudFront Distributions:
+		HorizontalRule
+
+		if [[ $DEBUGMODE = "1" ]]; then
+			echo "Debug distribution IDs:"
+			echo "$distributions"
+		fi
+		echo "$names"
+		echo
+	fi
+	TOTALDISTRIBUTIONS=$(echo "$distributions" | wc -l | rev | cut -d " " -f1 | rev)
+	if [[ $DEBUGMODE = "1" ]]; then
+		echo "$TOTALDISTRIBUTIONS"
+	fi
+}
+
+# List Invalidations
+function listInvalidations(){
+	# while IFS= read -r distributionid
+	# do
+	HorizontalRule
+	echo "Checking for Invalidations In Progress..."
+	HorizontalRule
+
+	START=1
+	for (( COUNT=$START; COUNT<=$TOTALDISTRIBUTIONS; COUNT++ ))
+	do
+		distributionid=$(echo "$distributions" | nl | grep -w [^0-9][[:space:]]$COUNT | cut -f2)
+
+		if [[ $DEBUGMODE = "1" ]]; then
+			echo "Debug distribution ID: $distributionid"
+		fi
+		invalidations=$(aws cloudfront list-invalidations --distribution-id $distributionid --profile $profile 2>&1 | jq '.InvalidationList | .Items | .[] | select(.Status != "Completed") | .Id' | cut -d \" -f2)
+		if [[ $DEBUGMODE = "1" ]]; then
+			echo invalidations "$invalidations"
+		fi
+
+		if ! [ -z "$invalidations" ]; then
+			HorizontalRule
+			echo "Invalidation in progress: $invalidations"
+			HorizontalRule
+		fi
+	done
+
+	# done <<< "$distributions"
+}
+
+# Check the Invalidation Status
+function checkInvalidationstatus(){
+	if [ -z "$invalidations" ]; then
+		echo No CloudFront Invalidations In Progress.
+		HorizontalRule
+		return 1
+	else
+		while IFS= read -r invalidationid
+		do
+			echo Invalidation ID: $invalidationid
+			invalidationStatus=$(aws cloudfront get-invalidation --distribution-id $distributionid --id $invalidationid --profile $profile 2>&1 | jq '.Invalidation | .Status' | cut -d \" -f2)
+
+			while [ $invalidationStatus = "InProgress" ]; do
+				HorizontalRule
+				echo "Invalidation Status:" $invalidationStatus
+				echo "Waiting for invalidation to complete..."
+				HorizontalRule
+				sleep 30
+				checkInvalidationstatus
+			done
+
+			if [ "$(uname)" == "Darwin" ]; then
+				if [[ $DEBUGMODE = "1" ]]; then
+					echo MACOS
+				fi
+				osascript -e 'tell app "Terminal" to display dialog " CloudFront Invalidation ID: '$invalidationid' Status: '$invalidationStatus'"'
+			elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+				if [[ $DEBUGMODE = "1" ]]; then
+					LINUX
+				fi
+				echo "CloudFront Invalidation $invalidationStatus"
+				completed
+			fi
+		done <<< "$invalidations"
+	fi
+}
+
+check_command "jq"
+distributionsCheck
+listDistributions
+listInvalidations
+checkInvalidationstatus

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # Modified from https://github.com/swoodford/aws/blob/master/cloudfront-invalidation-status.sh
-# Cloudfront ID is known ahead of time, but script can still handle multiple concurrent invalidations on the same distribution
 
 # This script monitors CloudFront distributions for cache invalidation status and alerts when it has completed
 # Requires the AWS CLI and jq
@@ -20,15 +19,6 @@ function scriptExit(){
 	HorizontalRule
 	echo
 	exit 0
-}
-
-# Invalidation Completed
-function completed(){
-	echo
-	HorizontalRule
-	echo "Invalidation Completed!"
-	HorizontalRule
-	echo
 }
 
 # Fail
@@ -78,7 +68,7 @@ function checkInvalidationstatus(){
 
 			if [ $invalidationStatus = "Completed" ]; then
 				echo "CloudFront Invalidation $invalidationStatus"
-				completed
+				scriptExit
 			fi
 		done <<< "$invalidations"
 	fi
@@ -87,4 +77,3 @@ function checkInvalidationstatus(){
 checkCommand "jq"
 listInvalidations
 checkInvalidationstatus
-scriptExit

--- a/scripts/check_invalidations.sh
+++ b/scripts/check_invalidations.sh
@@ -59,26 +59,10 @@ function checkInvalidationstatus(){
 		while IFS= read -r invalidationid
 		do
 			echo "Waiting for invalidation $invalidationid to complete..."
+			# Poll every 20 seconds, Wait until invalidation has completed
 			aws cloudfront wait invalidation-completed --distribution-id "$CLOUDFRONT_DIST_ID" --id "$invalidationid"
-			# # jq used to parse aws json output
-			# invalidationStatus=$(aws cloudfront get-invalidation --distribution-id $CLOUDFRONT_DIST_ID --id $invalidationid | jq '.Invalidation | .Status' | cut -d \" -f2)
-
-			# # While invalidation in progress, sleep for 10 seconds and check again
-			# while [ $invalidationStatus = "InProgress" ]; do
-			# 	HorizontalRule
-			# 	echo "Invalidation ID: $invalidationid" 
-			# 	echo "Status: $invalidationStatus"
-			# 	echo "Waiting for invalidation to complete..."
-			# 	HorizontalRule
-			# 	sleep 10
-			# 	checkInvalidationstatus
-			# done
-
-			# # If invalidation completes, exit the script
-			# if [ $invalidationStatus = "Completed" ]; then
-			# 	echo "CloudFront Invalidation $invalidationStatus"
-			# 	scriptExit
-			# fi
+			echo "Invalidation $invalidationid completed"
+			HorizontalRule
 		done <<< "$invalidations"
 		# All invalidations completed, exit script
 		scriptExit
@@ -87,7 +71,7 @@ function checkInvalidationstatus(){
 
 # Make sure jq exists on the system
 checkCommand "jq"
-# Grab invalidations
+# Grab all invalidations
 listInvalidations
 # Make sure invalidations are completed
 checkInvalidationstatus


### PR DESCRIPTION
### What does this MR do?

- Check Invalidation is Complete before Triggering Site Workflow
- Make necessary changes to prod pipeline to make it identical to dev pipeline

### Background info

Script used is a modified, simplified version of https://github.com/swoodford/aws/blob/master/cloudfront-invalidation-status.sh.

IAM policy for user was modified to include the permissions cloudfront:ListInvalidations , cloudfront:GetInvalidation necessary for the script.

### How can this be tested (manually and/or automated test)?

Tested successfully. https://github.com/CityOfLosAngeles/open-sdg-data-starter/actions/runs/677188608

### Which issue(s) is/are related to this PR?

This PR is/are related to issue(s) issue #14

close #14